### PR TITLE
feat(config): 🎸Add Default SEO config

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "immer": "^10.0.1",
     "lodash": "^4.17.21",
     "next": "^13.2.4",
+    "next-seo": "^6.1.0",
     "react": "^18.2.0",
     "react-cookie": "^4.1.1",
     "react-datepicker": "^4.10.0",

--- a/public/sitemap.json
+++ b/public/sitemap.json
@@ -1,1 +1,1 @@
-["","/auth","/social/callback"]
+["", "/auth", "/social/callback"]

--- a/public/sitemap.json
+++ b/public/sitemap.json
@@ -1,1 +1,1 @@
-["", "/auth", "/social/callback"]
+["","/auth","/social/callback"]

--- a/src/configs/seo/config.ts
+++ b/src/configs/seo/config.ts
@@ -1,19 +1,31 @@
 import { DefaultSeoProps } from 'next-seo';
 
+/**
+ * 페이지에 해당 메타태그가 적용되어 있지 않을 경우, 기본적으로 적용되는 SEO 설정입니다.
+ * noindex, nofollow 설정은 각 페이지 단에서 지정하여 사용하는 것을 권장합니다.
+ * noindex, nofollow의 기본 설정값은 false입니다.
+ * @see https://github.com/garmeeh/next-seo
+ */
+
 export const config: DefaultSeoProps = {
-  title: undefined,
-  titleTemplate: '똑똑한 개발자 | %s',
-  defaultTitle: '똑똑한 개발자',
-  description: '디지털프로덕트의 TOKTOK한 경험',
-  canonical: 'https://www.toktokhan.dev/',
+  title: undefined, // 페이지의 meta title 입니다. defaultTitle 값이 있으면 undefined로 고정합니다.
+  titleTemplate: '똑똑한 개발자 | %s', // 타이틀에 추가될 기본 title 템플릿입니다. 각 페이지에서 작성한 title이 %s에 적용됩니다.
+  defaultTitle: '똑똑한 개발자', // 페이지에 title이 설정되어 있지 않으면 빈 정보 대신 defaultTitle이 사용됩니다.
+  description: '디지털프로덕트의 TOKTOK한 경험', // 페이지의 meta 설명 설정입니다.
+  canonical: 'https://www.toktokhan.dev/', // 페이지의 표준 URL 설정입니다.
   openGraph: {
-    type: 'website',
-    locale: 'ko_KR',
-    url: 'https://www.toktokhan.dev/',
-    title: '똑똑한 개발자',
-    siteName: '똑똑한 개발자',
-    description: '디지털프로덕트의 TOKTOK한 경험',
+    /**
+     * Open Graph Protocol에 대한 자세한 설명은 아래의 링크를 참조합니다.
+     * @see https://ogp.me/
+     */
+    title: '똑똑한 개발자', // 사이트의 제목 태그입니다.
+    type: 'website', // 사이트의 종류입니다.
+    locale: 'ko_KR', // 사이트의 언어 설정입니다.
+    url: 'https://www.toktokhan.dev/', // 사이트의 대표 URL입니다.
+    siteName: '똑똑한 개발자', // 전체 사이트에 대해 표시되어야 하는 이름입니다.
+    description: '디지털프로덕트의 TOKTOK한 경험', // 사이트에 대한 설명입니다. meta description과 다를 수 있습니다.
     images: [
+      // 소셜 미디어 플랫폼, 슬랙 등에서 미리보기로 사용할 이미지의 배열입니다.
       {
         url: '/images/new_og.png',
         width: 600,
@@ -24,10 +36,12 @@ export const config: DefaultSeoProps = {
     ],
   },
   twitter: {
+    // 트위터에서 미리보기로 사용되는 Open Graph 설정입니다. next-seo 공식문서에서 제공하는 방식의 설정입니다.
     handle: '@handle',
     site: '@site',
     cardType: 'summary_large_image',
   },
+  // next-seo에서 다루지 않는 link tag를 적용합니다.
   additionalLinkTags: [
     {
       rel: 'shortcut icon',
@@ -67,6 +81,7 @@ export const config: DefaultSeoProps = {
     },
   ],
   additionalMetaTags: [
+    // next-seo에서 다루지 않는 meta tag를 적용합니다.
     {
       name: 'apple-mobile-web-app-capable',
       content: 'yes',

--- a/src/configs/seo/config.ts
+++ b/src/configs/seo/config.ts
@@ -1,0 +1,79 @@
+import { DefaultSeoProps } from 'next-seo';
+
+export const config: DefaultSeoProps = {
+  title: undefined,
+  titleTemplate: '똑똑한 개발자 | %s',
+  defaultTitle: '똑똑한 개발자',
+  description: '디지털프로덕트의 TOKTOK한 경험',
+  canonical: 'https://www.toktokhan.dev/',
+  openGraph: {
+    type: 'website',
+    locale: 'ko_KR',
+    url: 'https://www.toktokhan.dev/',
+    title: '똑똑한 개발자',
+    siteName: '똑똑한 개발자',
+    description: '디지털프로덕트의 TOKTOK한 경험',
+    images: [
+      {
+        url: '/images/new_og.png',
+        width: 600,
+        height: 315,
+        alt: 'Og Image Alt',
+        type: 'image/png',
+      },
+    ],
+  },
+  twitter: {
+    handle: '@handle',
+    site: '@site',
+    cardType: 'summary_large_image',
+  },
+  additionalLinkTags: [
+    {
+      rel: 'shortcut icon',
+      href: '/favicon.ico',
+      //   href: `{process.env.NEXT_PUBLIC_DOMAIN}/favicon.ico`,
+    },
+    {
+      rel: 'manifest',
+      href: '/manifest.json',
+    },
+    {
+      rel: 'apple-touch-icon',
+      href: '/icons/120.png',
+    },
+    {
+      rel: 'apple-touch-icon',
+      href: '/icons/152.png',
+      sizes: '152x152',
+    },
+    {
+      rel: 'apple-touch-icon',
+      href: '/icons/167.png',
+      sizes: '167x167',
+    },
+    {
+      rel: 'apple-touch-icon',
+      href: '/icons/180.png',
+      sizes: '180x180',
+    },
+    {
+      rel: 'preconnect',
+      href: 'https://fonts.googleapis.com',
+    },
+    {
+      rel: 'preconnect',
+      href: 'https://fonts.gstatic.com',
+    },
+  ],
+  additionalMetaTags: [
+    {
+      name: 'apple-mobile-web-app-capable',
+      content: 'yes',
+    },
+    {
+      name: 'format-detection',
+      content: 'telephone=no, address=no, email=no',
+    },
+  ],
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,5 @@
+import { DefaultSeo } from 'next-seo';
+
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import ControlledConfirmAlert from '@/components/@Alert/ControlledConfirmAlert';
@@ -5,10 +7,13 @@ import ToggleColorModeButton from '@/components/ToggleColorModeButton';
 import TokDocsDevTools from '@/components/TokDocsDevTool';
 import withAppProvider from '@/hocs/withAppProvider';
 
+import { config as SEO } from '@/configs/seo/config';
+
 function App({ Component, pageProps }: any) {
   return (
     <>
       {/* <Fonts /> */}
+      <DefaultSeo {...SEO} />
       <ToggleColorModeButton />
       <Component {...pageProps} />
       <ControlledConfirmAlert />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -11,11 +11,6 @@ import { ColorModeScript } from '@chakra-ui/color-mode';
 
 import config from '@/theme/config';
 
-const SITE_NAME = 'TOKTOKHAN.DEV';
-const SITE_TITLE = 'TOKTOKHAN.DEV';
-const SITE_DESCRIPTION = '디지털프로덕트의 TOKTOK한 경험';
-const SITE_IMAGE = '/images/new_og.png';
-
 // const GOOGLE_ANALYTICS_ID = 'G-입력해주세요';
 
 class MyDocument extends Document {
@@ -51,34 +46,6 @@ class MyDocument extends Document {
       <Html>
         <Head>
           <script dangerouslySetInnerHTML={this.redirectIEtoEdge()} />
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" />
-          {/* SEO */}
-          <link rel="apple-touch-icon" href="/icons/120.png" />
-          <link rel="apple-touch-icon" sizes="152x152" href="/icons/152.png" />
-          <link rel="apple-touch-icon" sizes="180x180" href="/icons/180.png" />
-          <link rel="apple-touch-icon" sizes="167x167" href="/icons/167.png" />
-          <meta name="apple-mobile-web-app-capable" content="yes" />
-
-          <link rel="canonical" href="https://www.toktokhan.dev/" />
-          <meta name="description" content={SITE_DESCRIPTION} />
-          <meta property="og:type" content="website" />
-          <meta property="og:site_name" content={SITE_NAME} />
-          <meta property="og:title" content={SITE_TITLE} />
-          <meta property="og:description" content={SITE_DESCRIPTION} />
-          <meta property="og:image" content={SITE_IMAGE} />
-          <meta name="twitter:card" content="summary_large_image" />
-          <meta name="twitter:site" content={SITE_NAME} />
-          <meta name="twitter:title" content={SITE_TITLE} />
-          <meta name="twitter:description" content={SITE_DESCRIPTION} />
-          <meta property="twitter:image" content={SITE_IMAGE} />
-          <meta
-            name="format-detection"
-            content="telephone=no, address=no, email=no"
-          />
-          <link rel="shortcut icon" href="/favicon.ico" />
-          <link rel="manifest" href="/manifest.json" />
-
           {/* Global site tag (gtag.js) - Google Analytics */}
           {/* <script
             async

--- a/src/pages/auth/index.tsx
+++ b/src/pages/auth/index.tsx
@@ -7,6 +7,8 @@ import withAuthGuard from '@/hocs/withAuthGuard';
 function AuthPage() {
   return (
     <>
+      {/* output: 똑똑한 개발자 | auth */}
+      {/* titleTemplate는 /configs/seo/config.ts에서 변경 가능합니다. */}
       <NextSeo title="auth" />
       <HomeLayout content={<Auth />} />
     </>

--- a/src/pages/auth/index.tsx
+++ b/src/pages/auth/index.tsx
@@ -1,4 +1,4 @@
-import Head from 'next/head';
+import { NextSeo } from 'next-seo';
 
 import HomeLayout from '@/components/@Layout/HomeLayout';
 import Auth from '@/containers/Auth';
@@ -7,10 +7,7 @@ import withAuthGuard from '@/hocs/withAuthGuard';
 function AuthPage() {
   return (
     <>
-      <Head>
-        {/* ex) Your App Name | Page Name */}
-        <title>똑똑한개발자 | auth</title>
-      </Head>
+      <NextSeo title="auth" />
       <HomeLayout content={<Auth />} />
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,8 @@ import withHomePageProvider from '@/hocs/withHomePageProvider';
 function HomePage() {
   return (
     <>
+      {/* output: 똑똑한 개발자 | 메인 */}
+      {/* titleTemplate는 /configs/seo/config.ts에서 변경 가능합니다. */}
       <NextSeo title="메인" />
       <HomeLayout content={<Home />} />
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Head from 'next/head';
+import { NextSeo } from 'next-seo';
 
 import HomeLayout from '@/components/@Layout/HomeLayout';
 import Home from '@/containers/Home';
@@ -9,10 +9,7 @@ import withHomePageProvider from '@/hocs/withHomePageProvider';
 function HomePage() {
   return (
     <>
-      <Head>
-        {/* ex) Your App Name | Page Name */}
-        <title>똑똑한 개발자 | 메인</title>
-      </Head>
+      <NextSeo title="메인" />
       <HomeLayout content={<Home />} />
     </>
   );

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,4 +1,4 @@
-import Head from 'next/head';
+import { NextSeo } from 'next-seo';
 
 import HomeLayout from '@/components/@Layout/HomeLayout';
 import Login from '@/containers/Login';
@@ -7,10 +7,7 @@ import withUnAuthGuard from '@/hocs/withUnAuthGuard';
 function LoginPage() {
   return (
     <>
-      <Head>
-        {/* ex) Your App Name | Page Name */}
-        <title>똑똑한개발자 | login</title>
-      </Head>
+      <NextSeo title="login" />
       <HomeLayout content={<Login />} />
     </>
   );

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -7,6 +7,8 @@ import withUnAuthGuard from '@/hocs/withUnAuthGuard';
 function LoginPage() {
   return (
     <>
+      {/* output: 똑똑한 개발자 | login */}
+      {/* titleTemplate는 /configs/seo/config.ts에서 변경 가능합니다. */}
       <NextSeo title="login" />
       <HomeLayout content={<Login />} />
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6591,6 +6591,11 @@ negotiator@^0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
+next-seo@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-6.1.0.tgz#b60b06958cc77e7ed56f0a61b2d6cd0afed88ebb"
+  integrity sha512-iMBpFoJsR5zWhguHJvsoBDxDSmdYTHtnVPB1ij+CD0NReQCP78ZxxbdL9qkKIf4oEuZEqZkrjAQLB0bkII7RYA==
+
 next@^13.2.4:
   version "13.3.1"
   resolved "https://registry.yarnpkg.com/next/-/next-13.3.1.tgz#17625f7423db2e059d71b41bd9031756cf2b33bc"


### PR DESCRIPTION
변경사항

-`next-seo` 라이브러리 추가
- `/configs/seo/config.ts` 경로에 `config.ts` 파일 추가
- `_app.tsx`에 Default SEO 컴포넌트 추가
- `_documents.tsx`에서 default seo와 중복되는 meta, link 태그 삭제
- 페이지의 각`index.tsx`에 `<NextSeo />` 컴포넌트 추가

