### PR TITLE
chore(LinkAsNext.tsx): 🤖fix: next-link with chakra-link

### DIFF
--- a/src/components/LinkAsNext.tsx
+++ b/src/components/LinkAsNext.tsx
@@ -35,6 +35,7 @@ const LinkAsNext = ({
       scroll={scroll}
       shallow={shallow}
       prefetch={prefetch}
+      style={{ width: '100%' }}
     >
       <ChakraLink //
         as={'span'}

--- a/src/components/LinkAsNext.tsx
+++ b/src/components/LinkAsNext.tsx
@@ -1,3 +1,6 @@
+import { PropsWithChildren } from 'react';
+
+import { LinkProps as NextLinkProps } from 'next/dist/client/link';
 import NextLink from 'next/link';
 
 import {
@@ -5,15 +8,41 @@ import {
   LinkProps as ChakraLinkProps,
 } from '@chakra-ui/react';
 
+export interface LinkAsNextProps
+  extends PropsWithChildren<
+    Omit<NextLinkProps, 'passHref'> & Omit<ChakraLinkProps, 'as' | 'href'>
+  > {}
+
 /**
  * @see Docs https://chakra-ui.com/docs/components/link/usage#usage-with-nextjs
  */
-const LinkAsNext = (props: ChakraLinkProps) => {
+const LinkAsNext = ({
+  href,
+  as,
+  replace,
+  scroll,
+  shallow,
+  prefetch,
+  children,
+  ...chakraProps
+}: LinkAsNextProps) => {
   return (
-    <ChakraLink //
-      as={NextLink}
-      {...props}
-    />
+    <NextLink
+      href={href}
+      as={as}
+      passHref={true}
+      replace={replace}
+      scroll={scroll}
+      shallow={shallow}
+      prefetch={prefetch}
+    >
+      <ChakraLink //
+        as={'span'}
+        {...chakraProps}
+      >
+        {children}
+      </ChakraLink>
+    </NextLink>
   );
 };
 


### PR DESCRIPTION
-ChakraLink의 as 기능: tag명을 설정
- NextLink의 as 기능: 브라우저에 노출될 url을 설정

**기존**
Chakra태그의 as 속성에 NextLink 태그를 전달하는 방식

**문제점**
LinkAsNext 컴포넌트에 as props 전달 시 의도와 다르게 작용 (의도: NextLink의 as 기능, 결과: ChakraLink의 as 기능) = 에러 발생

**변경**
NextLink를 ChakraLink의 외부에 래핑(LinkAsNext의 Props 타입 = NextLink+ChakraLink의 'as' 타입을 제외한 타입)

**특이사항**
ChakraLink의 as={'span'}을 준 이유: NextLink 태그(<a>)로 ChakraLink의 태그(<a>)를 감쌀 경우 <a>태그 내부에 또 다른 <a>태그가 존재할 수 없다는 에러 발생
