### PR TITLE
feat(format-server-errors.ts): 🎸format and style console output for s…

### DIFF
--- a/src/utils/logger/api-logger.ts
+++ b/src/utils/logger/api-logger.ts
@@ -2,12 +2,13 @@ import { CSSProperties } from 'react';
 
 import { AxiosRequestConfig } from 'axios';
 
+import { formatServerErrors } from './format-server-errors';
 import styledConsole, { StyledConsoleArgs } from './styled-console';
 
 interface ApiLoggerArgs extends Pick<StyledConsoleArgs, 'method'> {
   status: string | number;
   reqData?: AxiosRequestConfig;
-  resData: unknown;
+  resData: any;
 }
 
 export const apiLogger = ({
@@ -22,6 +23,12 @@ export const apiLogger = ({
     ? `?${new URLSearchParams(params).toString()}`
     : '';
 
+  const errors = (() => {
+    if (consoleMethod !== 'error') return '';
+    const errors = formatServerErrors(resData);
+    return errors.messages;
+  })();
+
   styledConsole({
     topic: `${METHOD}:${status}`,
     topicColor: METHOD_COLOR_MAP[METHOD] || 'black',
@@ -31,6 +38,7 @@ export const apiLogger = ({
       response: resData,
     },
     method: consoleMethod,
+    errors,
   });
 };
 

--- a/src/utils/logger/format-server-errors.ts
+++ b/src/utils/logger/format-server-errors.ts
@@ -1,0 +1,49 @@
+import { AxiosError } from 'axios';
+import { isObject } from 'lodash-es';
+
+const defMessage = '에러가 발생했습니다. 고객센터에 문의해주세요.';
+
+type ErrorMessage = {
+  [key: string]: any;
+};
+
+type FormattedError = {
+  name: string;
+  message: string;
+};
+
+export const formatServerErrors = <
+  T extends AxiosError<{ message: ErrorMessage }, any>,
+>(
+  errors: T,
+): {
+  defMessage?: string;
+  list?: FormattedError[];
+  messages?: string;
+} => {
+  const errorMsg = errors.response?.data.message;
+
+  if (!errorMsg) {
+    return { messages: errors.message };
+  }
+
+  const formatError = (errorKey: string, errorMessage: any): string => {
+    const message = isObject(errorMessage)
+      ? Object.values(errorMessage).join('\n')
+      : errorMessage;
+    return `[${errorKey}]: ${message}`;
+  };
+
+  const formattedErrors: FormattedError[] = Object.keys(errorMsg)
+    .filter((key) => key in errorMsg)
+    .map((key) => ({
+      name: key,
+      message: formatError(key, errorMsg[key]),
+    }));
+
+  const errorMessages = formattedErrors
+    .map((error) => error.message)
+    .join('\n');
+
+  return { defMessage, list: formattedErrors, messages: errorMessages };
+};

--- a/src/utils/logger/format-server-errors.ts
+++ b/src/utils/logger/format-server-errors.ts
@@ -1,8 +1,6 @@
 import { AxiosError } from 'axios';
 import { isObject } from 'lodash-es';
 
-const defMessage = '에러가 발생했습니다. 고객센터에 문의해주세요.';
-
 type ErrorMessage = {
   [key: string]: any;
 };
@@ -12,11 +10,17 @@ type FormattedError = {
   message: string;
 };
 
+type SeverError<T extends AxiosError<{ message: ErrorMessage }, any>> = {
+  errors: T;
+  defMessage?: string;
+};
+
 export const formatServerErrors = <
   T extends AxiosError<{ message: ErrorMessage }, any>,
->(
-  errors: T,
-): {
+>({
+  errors,
+  defMessage,
+}: SeverError<T>): {
   defMessage?: string;
   list?: FormattedError[];
   messages?: string;

--- a/src/utils/logger/styled-console.ts
+++ b/src/utils/logger/styled-console.ts
@@ -7,6 +7,7 @@ export type StyledConsoleArgs = {
   data: unknown;
   topicColor?: CSSProperties['color'];
   method?: 'log' | 'warn' | 'error' | 'info';
+  errors?: string;
 };
 
 function styledConsole({
@@ -15,12 +16,16 @@ function styledConsole({
   data,
   topicColor = 'skyblue',
   method = 'log',
+  errors = '',
 }: StyledConsoleArgs) {
   const term_1 = `%c[${topic}]`;
   const term_1_style = [`color: ${topicColor}`, 'font-weight : bold'].join(';');
   const term_2 = `%c${title}`;
   const term_2_style = ['font-weight : bold'].join(';');
+  const error_msg = `%c${errors}`;
+  const error_style = [`color: ${topicColor}`, 'font-weight : bold'].join(';');
   console[method](`${term_1}${term_2}`, term_1_style, term_2_style, data);
+  console[method](`${error_msg}`, error_style);
 }
 
 export default styledConsole;


### PR DESCRIPTION
###  Server error message 출력 
> api logger 로 출력하던 styled console log에서 에러가 날 경우 메세지를 출력하는 함수를 만들어 적용시켰습니다. 
기존 에러를 체크하면 콘솔 객체를 열어야하는 불편함이 줄어 수월한 작업이 되실 것이라고 생각합니다.  

- Before 
![Screenshot 2023-10-25 at 6 02 33 PM](https://github.com/TOKTOKHAN-DEV/next-init-2.0/assets/88864019/e86f59a8-6fac-4703-88b1-5f4d5c3efc47)


- After
![Screenshot 2023-10-25 at 6 02 44 PM](https://github.com/TOKTOKHAN-DEV/next-init-2.0/assets/88864019/7ec2ca9f-5feb-4fb1-953e-8988ce2df9cb)
![Screenshot 2023-10-20 at 11 05 45 AM](https://github.com/TOKTOKHAN-DEV/next-init-2.0/assets/88864019/81dbb883-41d3-47f5-8a78-1fcf991c54da)


### format-server-errors.ts
formatServerErrors 유틸함수를 onError 시 활용할 수 있습니다. (토스트, 알랏 띄울 때 등) 
```
const genErrorByServer: <T extends AxiosError<{
    message: ErrorMessage;
}, any>>(errors: T) => {
    defMessage?: string;
    list?: FormattedError[]; // error 리스트인경우 (여러 에러일경우)
    messages?: string; // 각 아이템들 줄바꿈 되어 string으로 출력 
}
```

### 활용 
```
 const openErrorToast = (
    errors: AxiosError<PaymentErrorType | CommonErrorType, any>,
  ) => {
    const error = genErrorByServer(errors);
    toast.open({
        title: '결제 시도 이슈',
        description: error.messages, // 여러 에러메세지가 있다면 줄바꿈으로 포맷되어 출력됨 
    });
  };
```




  
  
