### PR TITLE
feat(useInvalidateQuires.ts): 🎸for invalidate querykey

### DIFF
--- a/src/hooks/useInvalidateQuires.ts
+++ b/src/hooks/useInvalidateQuires.ts
@@ -5,24 +5,14 @@ import { QueryKey, useQueryClient } from '@tanstack/react-query';
 const useInvalidateQuires = () => {
   const queryClient = useQueryClient();
 
-  const single = useCallback(
-    (queryKey: QueryKey) => {
-      return queryClient.invalidateQueries(queryKey);
+  const invalidate = useCallback(
+    (...queryKeys: QueryKey[]) => {
+      queryKeys.forEach((queryKey) => queryClient.invalidateQueries(queryKey));
     },
     [queryClient],
   );
 
-  const multiple = useCallback(
-    (queryKeys: QueryKey[]) => {
-      const flatKeys = queryKeys.map((i) => i.concat());
-      flatKeys.map((queryKey) => {
-        return queryClient.invalidateQueries(queryKey);
-      });
-    },
-    [queryClient],
-  );
-
-  return { single, multiple };
+  return invalidate;
 };
 
 export default useInvalidateQuires;

--- a/src/hooks/useInvalidateQuires.ts
+++ b/src/hooks/useInvalidateQuires.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+
+import { QueryKey, useQueryClient } from '@tanstack/react-query';
+
+const useInvalidateQuires = () => {
+  const queryClient = useQueryClient();
+
+  const single = useCallback(
+    (queryKey: QueryKey) => {
+      return queryClient.invalidateQueries(queryKey);
+    },
+    [queryClient],
+  );
+
+  const multiple = useCallback(
+    (queryKeys: QueryKey[]) => {
+      const flatKeys = queryKeys.map((i) => i.concat());
+      flatKeys.map((queryKey) => {
+        return queryClient.invalidateQueries(queryKey);
+      });
+    },
+    [queryClient],
+  );
+
+  return { single, multiple };
+};
+
+export default useInvalidateQuires;


### PR DESCRIPTION
## 쿼리키 무효화 hook
> 기존의 React Query의 QueryKey를 무효화 시킬 때 여러 개의 쿼리키를 무효화 시키는 경우 queryClient.invalidateQueries()를 n 번 호출해야했던 점을 개선 했습니다.


### Example

```
const invalidate = useInvalidateQuires();
```
#### 단일 쿼리키 무효화 
> **const single: (queryKey: QueryKey) => Promise<void>**
```
  const { mutate } = useSomeCreateMutation({
    options: {
      onSuccess: () => {
       invalidate.single(QUERY_KEY_CHARGE_API.LIST_INFINITE({ query: { limit: 10 } }));
      },
    },
  });
```
#### 다중 쿼리키 무효화 
> **const multiple: (queryKeys: QueryKey[]) => void**

```
  const { mutate } = useSomeCreateMutation({
    options: {
      onSuccess: () => {
        invalidate.multiple([
          QUERY_KEY_BOOK_API.RETRIEVE({ secretKey: id }),
          QUERY_KEY_BOOK_LIKE_API.LIST(),
          QUERY_KEY_BOOK_LIKE_API.LIST_INFINITE(),
        ]);
      },
    },
  });
```

