### PR TITLE
Chore/install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict = true

--- a/package.json
+++ b/package.json
@@ -108,9 +108,9 @@
     "workerDirectory": "public"
   },
   "engines": {
+    "node": ">= 18.0.0",
     "npm": "Please Use \"yarn\"",
     "pnpm": "Please Use \"yarn\"",
-    "node": ">= 18.0.0",
     "yarn": ">= 1.22.17"
   },
   "os": [

--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "workerDirectory": "public"
   },
   "engines": {
+    "npm": "Please Use \"yarn\"",
     "node": ">= 18.0.0",
-    "npm": ">= 7.10.0",
     "yarn": ">= 1.22.17"
   },
   "os": [

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
   },
   "engines": {
     "npm": "Please Use \"yarn\"",
+    "pnpm": "Please Use \"yarn\"",
     "node": ">= 18.0.0",
     "yarn": ">= 1.22.17"
   },

--- a/package.json
+++ b/package.json
@@ -117,6 +117,5 @@
     "darwin",
     "win64",
     "linux"
-  ],
-  "engineStrict": true
+  ]
 }


### PR DESCRIPTION
패키지 설치시 새로운 lock 파일을 생성하게 됩니다.

- `npm install` 명령어 실행 -> package-lock.json
- `pnpm install` 명령어 실행 -> pnpm-lock.yaml
- `yarn install` 명령어 실행 -> yarn.lock

lock 파일을 기반으로 패키지를 설치하기 때문에 여러 lock 파일이 존재할 경우 의존성문제가 발생할 가능성이 다분합니다. 그래서 구두로 `yarn`을 사용하도록 개발팀 내부적으로 공유되고 있습니다. 지금은 내부적으로 잘 정착되어 package-lock.json 파일과 yarn.lock 대한 충돌문제는 발생하지 않고 있습니다.

그것보다 조금 더 안전하게 처리할 방법이 있지 않을까 생각하다가 `yarn` 또는 `yarn install` 명령어로만 패키지 설치가 가능하도록 수정하였습니다.

주요 변경파일
- package.json
- .npmrc

1. package.json의 `engines` 설정에 `npm`, `pnpm`에 대한 설정을 추가하였습니다.

2. package.json의 `engineStrict`에 대한 설정은 `yarn` 혹은 `pnpm`에서만 동작하는 것으로 확인되었습니다. 그래서 `npm install` 명령어 실행 시 `engineStrict`가 동작하지 않고 패키지가 설치됩니다(package-lock.json 파일이 생성됨). 그래서 package.json 내부 설정은 제거하고, 대신 .npmrc파일을 새로 생성하여 `engine-strict = true` 설정을 추가하였습니다.

3. 패키지 설치 도중 다음과 같은 `warning`문구가 나타납니다. package.json 내부의 `engines`설정에서 `pnpm` 버전을 제거하면 되지만, 정확히 pnpm에 대한 에러가 아닌 yarn classic(v1) 버전에 대한 문제로 보입니다. `yarn set version stable`명령어를 통해 안정된 yarn 버전(v2 이상)을 사용할 경우 warning이 사라집니다. 다만 지금 저희 보일러 플레이트는 yarn v1을 사용하고 있기 때문에 yarn 버전에 대한 것은 수정하지 않았습니다. yarn version 이외 불특정 패키지(`eg. chart.js@4.2.0`)로 인해 warning표시가 보여지는 경우도 있습니다. 근본적으로 해결할 수는 없는 문제로 판단되었습니다. 

<img width="500" alt="스크린샷 2023-11-06 오후 3 44 35" src="https://github.com/TOKTOKHAN-DEV/next-init-2.0/assets/51189962/21e9697b-b245-4671-8a0b-6cf70868d0d9">

--- 

> `npm install` 실행 시 다음과 같이 에러를 발생시키고, 패키지 설치를 차단합니다.
<img width="874" alt="스크린샷 2023-11-06 오후 3 30 14" src="https://github.com/TOKTOKHAN-DEV/next-init-2.0/assets/51189962/7f6cfd67-8388-45dc-9b0d-8e8d8a641979">

> `pnpm install` 실행 시 다음과 같은 에러를 발생시키고, 패키지 설치를 차단합니다.
<img width="670" alt="스크린샷 2023-11-06 오후 3 31 08" src="https://github.com/TOKTOKHAN-DEV/next-init-2.0/assets/51189962/9fff975b-cb41-4f3f-9070-3af1d3570c31">
  
> `yarn` 실행 시 다음과 같이 정상적으로 패키지가 설치됩니다.
<img width="577" alt="스크린샷 2023-11-06 오후 3 43 22" src="https://github.com/TOKTOKHAN-DEV/next-init-2.0/assets/51189962/7b1cdb41-89bb-4fb0-b93b-6967e10c6d56">

